### PR TITLE
fix: update command counting logic to use options.prefix

### DIFF
--- a/src/structure/BaseAgent.ts
+++ b/src/structure/BaseAgent.ts
@@ -134,7 +134,7 @@ export class BaseAgent {
         }
 
         this.client.sendMessage(content, options)
-        if (!!this.prefix) this.totalCommands++;
+        if (!!options.prefix) this.totalCommands++;
         else this.totalTexts++;
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `BaseAgent` class in `src/structure/BaseAgent.ts`. The change updates the logic to increment `totalCommands` based on the `options.prefix` property instead of the `this.prefix` property.