### PR TITLE
fix: update logging key from 'sleepTime' to 'duration' in autoSleep f…

### DIFF
--- a/src/features/autoSleep.ts
+++ b/src/features/autoSleep.ts
@@ -28,7 +28,7 @@ export default Schematic.registerFeature({
 
         logger.info(t("features.autoSleep.nextSleep", {
             commands: nextThreshold,
-            sleepTime: formatTime(0, mapInt(
+            duration: formatTime(0, mapInt(
                 nextThreshold,
                 52, 600, // Map the range of commands to the sleep time
                 5 * 60 * 1000, 40 * 60 * 1000


### PR DESCRIPTION
This pull request includes a minor update to the `src/features/autoSleep.ts` file. The change renames the `sleepTime` key to `duration` in the object passed to the logger for better clarity and consistency.