### PR TITLE
fix: handle case where response may be undefined in changePrefix feature

### DIFF
--- a/src/features/changePrefix.ts
+++ b/src/features/changePrefix.ts
@@ -20,9 +20,7 @@ export default Schematic.registerFeature({
             expectResponse: true,
         });
 
-        if (!response) return;
-
-        const newPrefix = response.content.match(/the current prefix is set to\s*\*\*`([^`]+)`\*\*/i)?.[1];
+        const newPrefix = response?.content.match(/the current prefix is set to\s*\*\*`([^`]+)`\*\*/i)?.[1];
         if (!newPrefix) {
             agent.config.useCustomPrefix = false;
             logger.warn(t("features.changePrefix.noPrefixFound"));


### PR DESCRIPTION
This pull request modifies the `src/features/changePrefix.ts` file to improve the handling of undefined or null values in the `response` object. The change simplifies the code by using optional chaining to safely access the `content` property.

Key change:

* Updated the `newPrefix` assignment to use optional chaining (`response?.content`) for safer access to the `content` property, ensuring the code handles cases where `response` might be undefined or null.