### PR TITLE
fix: update logging to use 'solution' key for captcha results in solvePassword function

### DIFF
--- a/src/features/autoHuntbot.ts
+++ b/src/features/autoHuntbot.ts
@@ -31,7 +31,7 @@ const solvePassword = async (attachmentUrl: string, options: SolvePasswordOption
             logger.warn(t("features.autoHuntbot.errors.invalidCaptchaResult", { result }));
             return undefined;
         }
-        logger.data(t("captcha.solutionFound", { result }));
+        logger.data(t("captcha.solutionFound", { solution: result }));
         return result;
     }
 
@@ -53,7 +53,7 @@ const solvePassword = async (attachmentUrl: string, options: SolvePasswordOption
             avgConfidence: string;
         };
 
-        logger.data(t("captcha.solutionFound", { result: res.result, avgConfidence: res.avgConfidence }));
+        logger.data(t("captcha.solutionFound", { solution: res.result, avgConfidence: res.avgConfidence }));
         return res.result;
     } catch (error) {
         logger.error("Failed to parse captcha response:");


### PR DESCRIPTION
This pull request updates logging in the `solvePassword` function of `src/features/autoHuntbot.ts` to improve clarity by renaming the `result` key to `solution` in logged messages.

### Logging improvements:

* [`src/features/autoHuntbot.ts`](diffhunk://#diff-d2c3321e54034de658140ab5eb67bd149fed5ae656e33ab7cafae27fd21ab941L34-R34): Changed the logging key from `result` to `solution` in the `captcha.solutionFound` message to better reflect the context of the logged data. [[1]](diffhunk://#diff-d2c3321e54034de658140ab5eb67bd149fed5ae656e33ab7cafae27fd21ab941L34-R34) [[2]](diffhunk://#diff-d2c3321e54034de658140ab5eb67bd149fed5ae656e33ab7cafae27fd21ab941L56-R56)